### PR TITLE
Change URL from Gitlab to Github (2 times)

### DIFF
--- a/Linux - OSX/Archive Scripts/Unique/Unique.sh
+++ b/Linux - OSX/Archive Scripts/Unique/Unique.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 #
 # TheFrenchGhostys YouTube-DL Archivist Scripts: The ultimate collection of scripts for YouTube-DL
-# https://gitlab.com/TheFrenchGhosty/TheFrenchGhostys-YouTube-DL-Archivist-Scripts
-# https://gitlab.com/TheFrenchGhosty
+# https://github.com/TheFrenchGhosty/TheFrenchGhostys-YouTube-DL-Archivist-Scripts
+# https://github.com/TheFrenchGhosty
 #
 #
 

--- a/Linux - OSX/Audio Only Script/Unique/Unique.sh
+++ b/Linux - OSX/Audio Only Script/Unique/Unique.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 #
 # TheFrenchGhostys YouTube-DL Archivist Scripts: The ultimate collection of scripts for YouTube-DL
-# https://gitlab.com/TheFrenchGhosty/TheFrenchGhostys-YouTube-DL-Archivist-Scripts
-# https://gitlab.com/TheFrenchGhosty
+# https://github.com/TheFrenchGhosty/TheFrenchGhostys-YouTube-DL-Archivist-Scripts
+# https://github.com/TheFrenchGhosty
 #
 #
 


### PR DESCRIPTION
Hi,

i found 2 places where the old gitlab.com link was still in use and changed it to github.com.

Greetings,
Stefomat